### PR TITLE
Bump version to 0.1.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parsec-client-test"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Ionut Mihalcea <ionut.mihalcea@arm.com>",
            "Hugues de Valon <hugues.devalon@arm.com>"]
 edition = "2018"


### PR DESCRIPTION
Needed so we can pull the log changes into the `parsec` tests.