### PR TITLE
Fix import key size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parsec-client-test"
-version = "0.1.3"
+version = "0.1.5"
 authors = ["Ionut Mihalcea <ionut.mihalcea@arm.com>",
            "Hugues de Valon <hugues.devalon@arm.com>"]
 edition = "2018"

--- a/src/abstract_test_client.rs
+++ b/src/abstract_test_client.rs
@@ -202,7 +202,7 @@ impl TestClient {
                 key_type,
                 ecc_curve: None,
                 algorithm,
-                key_size: key_data.len() as u32,
+                key_size: 0,
                 permit_sign: true,
                 permit_verify: true,
                 permit_export: true,


### PR DESCRIPTION
This commit fixes the key size set by in the import operation in the
abstract test client. Previously, the value was set to the length of
the data passed as the key to be imported, in bytes, which is incorrect
in two ways:
* The length should be in bits
* The length should cover only the key, not the surrounding metadata as
well

Setting it to 0 is correct in the current definition of the PSA spec, as
the `data_len` field passed in the operation is enough.