### PR TITLE
Destroy keys created in the stress test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "parsec-client-test"
-version = "0.1.6"
-authors = ["Ionut Mihalcea <ionut.mihalcea@arm.com>",
+version = "0.1.7"
+authors = ["Paul Howard <paul.howard@arm.com>",
+           "Ionut Mihalcea <ionut.mihalcea@arm.com>",
            "Hugues de Valon <hugues.devalon@arm.com>"]
 edition = "2018"
 
 [dependencies]
-parsec-interface = { git = "https://github.com/parallaxsecond/parsec-interface-rs", tag = "0.2.1"  }
+parsec-interface = { git = "https://github.com/parallaxsecond/parsec-interface-rs", tag = "0.3.0"  }
 num = "0.2.0"
 rand = "0.7.2"
 log = "0.4.8"


### PR DESCRIPTION
The stress tests might be executed on a system with limited storage so
destroying keys will help.
Pulls in new version of the interface as well.