### PR TITLE
Update Parsec interface version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "parsec-client-test"
-version = "0.1.7"
+version = "0.1.8"
 authors = ["Paul Howard <paul.howard@arm.com>",
            "Ionut Mihalcea <ionut.mihalcea@arm.com>",
            "Hugues de Valon <hugues.devalon@arm.com>"]
 edition = "2018"
 
 [dependencies]
-parsec-interface = { git = "https://github.com/parallaxsecond/parsec-interface-rs", tag = "0.3.0"  }
+parsec-interface = { git = "https://github.com/parallaxsecond/parsec-interface-rs", tag = "0.4.0"  }
 num = "0.2.0"
 rand = "0.7.2"
 log = "0.4.8"

--- a/src/abstract_test_client.rs
+++ b/src/abstract_test_client.rs
@@ -96,7 +96,7 @@ impl TestClient {
         self.cached_opcodes = Some(map);
     }
 
-    fn get_cached_provider(&mut self, opcode: Opcode) -> ProviderID {
+    pub fn get_cached_provider(&mut self, opcode: Opcode) -> ProviderID {
         if self.cached_opcodes.is_none() {
             self.build_cache();
         }


### PR DESCRIPTION
After the TPM was added in the interface, a new version is also needed
for the tests.
Also make the get_cached_provider function public so that the test can
be ignored for some providers.
Will not build until parallaxsecond/parsec-interface-rs#9 is merged.