### PR TITLE
Bump interface version; set body length limit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "parsec-client-test"
-version = "0.1.12"
+version = "0.1.13"
 authors = ["Paul Howard <paul.howard@arm.com>",
            "Ionut Mihalcea <ionut.mihalcea@arm.com>",
            "Hugues de Valon <hugues.devalon@arm.com>"]
 edition = "2018"
 
 [dependencies]
-parsec-interface = { git = "https://github.com/parallaxsecond/parsec-interface-rs", tag = "0.5.1"  }
+parsec-interface = { git = "https://github.com/parallaxsecond/parsec-interface-rs", tag = "0.6.0"  }
 num = "0.2.0"
 rand = "0.7.2"
 log = "0.4.8"

--- a/src/request_test_client.rs
+++ b/src/request_test_client.rs
@@ -19,6 +19,8 @@ use std::os::unix::net::UnixStream;
 use std::thread;
 use std::time::Duration;
 
+const MAX_BODY_SIZE: usize = 1 << 31;
+
 /// Low level client structure to send a `Request` and get a `Response`.
 #[derive(Copy, Clone, Debug)]
 pub struct RequestTestClient {
@@ -57,7 +59,7 @@ impl RequestTestClient {
         request
             .write_to_stream(&mut stream)
             .expect("Failed to write request to socket.");
-        Response::read_from_stream(&mut stream)
+        Response::read_from_stream(&mut stream, MAX_BODY_SIZE)
     }
 
     /// Send a raw request.
@@ -86,6 +88,6 @@ impl RequestTestClient {
             .write_all(&bytes)
             .expect("Failed to write bytes to stream");
 
-        Response::read_from_stream(&mut stream)
+        Response::read_from_stream(&mut stream, MAX_BODY_SIZE)
     }
 }


### PR DESCRIPTION
This commit gets the client up to speed with the body length limit
added to the interface.