### PR TITLE
Replace simple by direct

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parsec-client-test"
-version = "0.1.16"
+version = "0.1.17"
 authors = ["Paul Howard <paul.howard@arm.com>",
            "Ionut Mihalcea <ionut.mihalcea@arm.com>",
            "Hugues de Valon <hugues.devalon@arm.com>"]
@@ -14,7 +14,7 @@ edition = "2018"
 publish = false
 
 [dependencies]
-parsec-interface = "0.8.1"
+parsec-interface = "0.8.2"
 num = "0.2.0"
 rand = "0.7.2"
 log = "0.4.8"

--- a/src/abstract_test_client.rs
+++ b/src/abstract_test_client.rs
@@ -36,7 +36,7 @@ pub struct TestClient {
 }
 
 impl TestClient {
-    /// Creates a TestClient instance with no provider or authentication set.
+    /// Creates a TestClient instance with no provider and a default authentication value of "root".
     ///
     /// For each request, a provider able to execute the operation will be chosen.
     /// The keys creates by this client will be automatically destroyed when it is dropped unless
@@ -46,7 +46,7 @@ impl TestClient {
             op_client: OperationTestClient::new(),
             cached_opcodes: None,
             provider: None,
-            auth: RequestAuth::from_bytes(Vec::new()),
+            auth: RequestAuth::from_bytes(Vec::from("root")),
             created_keys: Some(HashSet::new()),
         }
     }

--- a/src/operation_test_client.rs
+++ b/src/operation_test_client.rs
@@ -37,7 +37,7 @@ pub struct OperationTestClient {
 #[allow(clippy::new_without_default)]
 impl OperationTestClient {
     /// Creates a OperationTestClient instance. The minimal client uses a timeout of 5 seconds on reads
-    /// and writes on the socket. It uses the version 1.0 to form request, the simple
+    /// and writes on the socket. It uses the version 1.0 to form request, the direct
     /// authentication method and protobuf format as content type.
     pub fn new() -> OperationTestClient {
         OperationTestClient {
@@ -46,7 +46,7 @@ impl OperationTestClient {
             version_min: 0,
             content_type: BodyType::Protobuf,
             accept_type: BodyType::Protobuf,
-            auth_type: AuthType::Simple,
+            auth_type: AuthType::Direct,
             request_client: RequestTestClient::new(),
         }
     }


### PR DESCRIPTION
The new behaviour of the direct authenticator is that it will reject an
empty authentication string. To fix the Parsec tests without having to
change them, use a default authentication value of "root".

Signed-off-by: Hugues de Valon <hugues.devalon@arm.com>