### PR TITLE
Put the key attributes as an input

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,7 +87,7 @@
 //!
 //!let mut client = TestClient::new();
 //!let key_name = String::from("🔑 What shall I sign? 🔑");
-//!client.create_rsa_sign_key(key_name.clone()).unwrap();
+//!client.generate_rsa_sign_key(key_name.clone()).unwrap();
 //!let signature = client.sign_with_rsa_sha256(key_name,
 //!                            String::from("Platform AbstRaction for SECurity").into_bytes())
 //!                      .unwrap();

--- a/src/stress_test_client.rs
+++ b/src/stress_test_client.rs
@@ -120,7 +120,7 @@ impl StressTestWorker {
         // Create sign/verify key
         let test_key_name = generate_string(10);
         client
-            .create_rsa_sign_key(test_key_name.clone())
+            .generate_rsa_sign_key(test_key_name.clone())
             .expect("Failed to create key");
 
         StressTestWorker {
@@ -154,7 +154,7 @@ impl StressTestWorker {
                 let key_name = generate_string(10);
                 info!("Creating key with name: {}", key_name);
                 self.client
-                    .create_rsa_sign_key(key_name.clone())
+                    .generate_rsa_sign_key(key_name.clone())
                     .expect("Failed to create key");
                 self.client
                     .destroy_key(key_name)
@@ -244,7 +244,7 @@ impl ServiceChecker {
         loop {
             info!("Verifying that the service is still operating correctly");
             client
-                .create_rsa_sign_key(key_name.clone())
+                .generate_rsa_sign_key(key_name.clone())
                 .expect("Failed to create signing key");
 
             let signature = client


### PR DESCRIPTION
It allows the caller to specify the key attributes they want when
generating a key.

Signed-off-by: Hugues de Valon <hugues.devalon@arm.com>